### PR TITLE
Fix slow queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: php
 
 php:

--- a/classes.groups.php
+++ b/classes.groups.php
@@ -385,7 +385,7 @@ class BU_Edit_Groups {
 
 		}
 
-		$count_query = sprintf( "SELECT DISTINCT( ID ) FROM %s, %s WHERE ID = post_ID AND ( meta_key = '%s' AND meta_value IN (%s) %s) %s",
+		$count_query = sprintf( "SELECT DISTINCT( ID ) FROM %s AS p JOIN %s AS m ON p.ID = m.post_ID WHERE ( m.meta_key = '%s' AND m.meta_value IN (%s) %s ) %s",
 			$wpdb->posts,
 			$wpdb->postmeta,
 			BU_Group_Permissions::META_KEY,

--- a/classes.groups.php
+++ b/classes.groups.php
@@ -385,7 +385,7 @@ class BU_Edit_Groups {
 
 		}
 
-		$count_query = sprintf( "SELECT DISTINCT( ID ) FROM %s AS p JOIN %s AS m ON p.ID = m.post_ID WHERE ( m.meta_key = '%s' AND m.meta_value IN (%s) %s ) %s",
+		$count_query = sprintf( "SELECT DISTINCT( ID ) FROM %s AS p LEFT JOIN %s AS m ON p.ID = m.post_ID WHERE ( m.meta_key = '%s' AND m.meta_value IN (%s) %s ) %s",
 			$wpdb->posts,
 			$wpdb->postmeta,
 			BU_Group_Permissions::META_KEY,

--- a/tests/phpunit/test-roles-caps.php
+++ b/tests/phpunit/test-roles-caps.php
@@ -15,7 +15,11 @@ class Test_BU_Section_Editing_Caps extends WP_UnitTestCase {
 		$upgrader = new BU_Section_Editing_Upgrader();
 		$upgrader->populate_roles();
 
-		$this->groups = array();
+		$this->groups 	= array();
+		$this->users 	= array();
+		$this->posts 	= array();
+		$this->pages 	= array();
+
 		$pages = array(
 			'top-level1' => array(
 				'status' => 'publish'
@@ -71,8 +75,10 @@ class Test_BU_Section_Editing_Caps extends WP_UnitTestCase {
 		);
 		$this->addUser('section_editor1');
 		$this->addUser('section_editor2');
+		
 		$section_editor1 = get_user_by('login', 'section_editor1');
 		$section_editor2 = get_user_by('login', 'section_editor2');
+		
 		$this->insertPosts($pages, 'page');
 		$this->insertPosts($posts, 'post');
 		$perms = $this->getEditable('alpha');


### PR DESCRIPTION
Adding JOIN to SQL requests improves performance for large tables.

Before (77,000ms): https://www.dropbox.com/s/a71uvxwvs98vlu5/Screenshot%202016-01-06%2014.30.17.png?dl=0

After (218ms): https://www.dropbox.com/s/sbb52i2k68vm9qi/Screenshot%202016-01-06%2014.30.46.png?dl=0