### PR TITLE
Exclude buse post type from search. RE: INC12697903

### DIFF
--- a/classes.groups.php
+++ b/classes.groups.php
@@ -68,7 +68,7 @@ class BU_Edit_Groups {
 			'menu_icon'           => '',
 			'can_export'          => true,
 			'has_archive'         => false,
-			'exclude_from_search' => false,
+			'exclude_from_search' => true,
 			'publicly_queryable'  => false,
 			'rewrite'             => false,
 			'capability_type'     => 'post',


### PR DESCRIPTION
In the post type registration the 'public' setting is 'false' which would hide the group from search by default but the 'exclude_from_search' had been set to false. This caused section groups to be returned in WP search results.