### PR TITLE
Fix a handful of incorrectly prepared queries

### DIFF
--- a/classes.permissions.php
+++ b/classes.permissions.php
@@ -122,7 +122,7 @@ class BU_Group_Permissions {
 				// Select meta_id's for removal based on incoming posts
 				$denied_meta_ids = $wpdb->get_col(
 					$wpdb->prepare(
-						"SELECT meta_id FROM {$wpdb->postmeta} WHERE post_id IN ({$ids}) AND meta_key = %s AND meta_value = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+						"SELECT meta_id FROM {$wpdb->postmeta} WHERE post_id IN ({$denied_ids}) AND meta_key = %s AND meta_value = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 						self::META_KEY,
 						$group_id
 					)

--- a/classes.permissions.php
+++ b/classes.permissions.php
@@ -116,11 +116,13 @@ class BU_Group_Permissions {
 
 			if ( ! empty( $denied_ids ) ) {
 
+				// Sanitize the list of IDs for direct use in the query.
+				$denied_ids = implode( ',', array_map( 'intval', $denied_ids ) );
+
 				// Select meta_id's for removal based on incoming posts
 				$denied_meta_ids = $wpdb->get_col(
 					$wpdb->prepare(
-						"SELECT meta_id FROM {$wpdb->postmeta} WHERE post_id IN (%s) AND meta_key = %s AND meta_value = %s",
-						implode( ',', array_map( 'intval', $denied_ids ) ),
+						"SELECT meta_id FROM {$wpdb->postmeta} WHERE post_id IN ({$ids}) AND meta_key = %s AND meta_value = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 						self::META_KEY,
 						$group_id
 					)
@@ -129,13 +131,11 @@ class BU_Group_Permissions {
 				// Bulk deletion
 				if ( ! empty( $denied_meta_ids ) ) {
 
+					// Sanitize the list of IDs for direct use in the query.
+					$denied_meta_ids = implode( ',', array_map( 'intval', $denied_meta_ids ) );
+
 					// Remove allowed status in one query
-					$wpdb->query(
-						$wpdb->prepare(
-							"DELETE FROM $wpdb->postmeta WHERE meta_id IN (%s)",
-							implode( ',', array_map( 'intval', $denied_meta_ids ) )
-						)
-					);
+					$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE meta_id IN ({$denied_meta_ids})" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 					// Purge cache
 					foreach ( $denied_ids as $post_id ) {
@@ -744,11 +744,13 @@ class BU_Hierarchical_Permissions_Editor extends BU_Permissions_Editor {
 			/* Gather all group post meta in one shot */
 			$ids = array_keys( $posts );
 
+			// Sanitize the list of IDs for direct use in the query.
+			$ids = implode( ',', array_map( 'intval', $ids ) );
+
 			$group_meta = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN (%s) AND meta_value = %s",
+					"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN ({$ids}) AND meta_value = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					BU_Group_Permissions::META_KEY,
-					implode( ',', array_map( 'intval', $ids ) ),
 					$this->group->id
 				),
 				OBJECT_K

--- a/plugin-support/bu-navigation/section-editor-nav.php
+++ b/plugin-support/bu-navigation/section-editor-nav.php
@@ -57,12 +57,16 @@ function buse_bu_navigation_filter_posts( $posts ) {
 			/* Gather all group post meta in one shot */
 			$ids = array_keys( $posts );
 
+			// Sanitize the list of IDs for direct use in a query.
+			$ids = implode( ',', array_map( 'intval', $ids ) );
+
+			// Sanitize the list of groups for direct use in a query.
+			$section_groups_values = implode( ',', array_map( 'intval', $section_groups ) );
+
 			$group_meta = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN (%s) AND meta_value IN (%s)",
-					BU_Group_Permissions::META_KEY,
-					implode( ',', array_map( 'intval', $ids ) ),
-					implode( ',', array_map( 'intval', $section_groups ) )
+					"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN ({$ids}) AND meta_value IN ({$section_groups_values})", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					BU_Group_Permissions::META_KEY
 				)
 				, OBJECT_K
 			); // get results as objects in an array keyed on post_id


### PR DESCRIPTION
In the original version, `sprintf()` was used to prepare the query:

```
sprintf( "SELECT post_id, meta_value FROM %s WHERE meta_key = '%s' AND post_id IN (%s) AND meta_value = '%s'", $wpdb->postmeta, 'custom_meta_key', implode( ',', $ids ), $group_id );
```

This generated this query:

`SELECT post_id, meta_value FROM wp_postmeta WHERE meta_key = 'custom_meta_key' AND post_id IN (1,2,3) AND meta_value = '123'`

The buggy switch to `$wpdb->prepare()` used a `%s` placeholder to insert a list of integers and the query turned into:

`// SELECT post_id, meta_value FROM wp_postmeta WHERE meta_key = 'custom_meta_key' AND post_id IN ('1,2,3') AND meta_value = '123'`

The proper way to handle this is to prepare the list of integers for use in an `IN` clause beforehand and then just use the variable directly. It creates a PHPCS error that we can safely ignore.

@DannyCrews brought up one example and I found a few other queries in this plugin using the same pattern. I searched through the rest of the BU code base and did not find any others. I'm fairly confident that this was a slip and that I handled it correctly elsewhere.